### PR TITLE
Fix -dirty check for Lineage 17.1

### DIFF
--- a/scripts/setlocalversion
+++ b/scripts/setlocalversion
@@ -87,8 +87,16 @@ scm_version()
 			printf -- '-svn%s' "`git svn find-rev $head`"
 		fi
 
-		# Check for uncommitted changes
-		if git diff-index --name-only HEAD | grep -qv "^scripts/package"; then
+		# Check for uncommitted changes.
+		# First, with git-status, but --no-optional-locks is only
+		# supported in git >= 2.14, so fall back to git-diff-index if
+		# it fails. Note that git-diff-index does not refresh the
+		# index, so it may give misleading results. See
+		# git-update-index(1), git-diff-index(1), and git-status(1).
+		if {
+			git --no-optional-locks status -uno --porcelain 2>/dev/null ||
+			git diff-index --name-only HEAD
+		} | grep -qvE '^(.. )?scripts/package'; then
 			printf '%s' -dirty
 		fi
 


### PR DESCRIPTION
Building this kernel (and others) alongside the ROM in Lineage 17.1 appends "-dirty" to the version string, even if the kernel is being built cleanly.
The commit attached to this pull request fixes the issue.